### PR TITLE
Build image for multiple architectures (include M1 Macs)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: masstransit/rabbitmq:latest
+          tags: duochjagochpensionarerna/rabbitmq:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,5 +27,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: masstransit/rabbitmq:latest
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: duochjagochpensionarerna/rabbitmq:latest
+          tags: masstransit/rabbitmq:latest


### PR DESCRIPTION
Hi!
I'm using this image for a project of mine, and currently I bought an M1 Mac. Unfortunately it doesn't look like quemu is working properly (or I've missed setting something up?). This can be fixed by also building for `linux/arm64`. 

For comparison: The last run of the GitHub action took ~31s. When I tested it with building for both architectures, it took ~44s. So not that much more 😊 