### PR TITLE
Properly tag Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,14 +15,26 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push image to DockerHub
-        uses: docker/build-push-action@v3
+      - name: Read RabbitMQ version
+        run: |
+          RABBITMQ_VERSION=$(grep "rabbitmq:" Dockerfile | cut -d ":" -f 2 | cut -d "-" -f 1)
+          RABBITMQ_MAJOR=$(echo $RABBITMQ_VERSION | cut -d "." -f 1)
+          RABBITMQ_MINOR=$(echo $RABBITMQ_VERSION | cut -d "." -f 2)
+          echo "RABBITMQ_VERSION=$RABBITMQ_VERSION" >> $GITHUB_ENV
+          echo "RABBITMQ_MAJOR=$RABBITMQ_MAJOR" >> $GITHUB_ENV
+          echo "RABBITMQ_MINOR=$RABBITMQ_MINOR" >> $GITHUB_ENV
+      - name: Build and push image to Docker Hub
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: masstransit/rabbitmq:latest
+          tags: |
+            masstransit/rabbitmq:${{ env.RABBITMQ_MAJOR }}
+            masstransit/rabbitmq:${{ env.RABBITMQ_MAJOR }}.${{ env.RABBITMQ_MINOR }}
+            masstransit/rabbitmq:${{ env.RABBITMQ_VERSION }}
+            masstransit/rabbitmq:latest

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # RabbitMQ with delayed exchange
 
-This repository contains the [RabbitMQ](https://hub.docker.com/_/rabbitmq) **management-alpine** image with [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin enabled.
+This repository contains the [RabbitMQ](https://hub.docker.com/_/rabbitmq) `management` Docker image with [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin enabled.
 
 This image is build to be used with [MassTransit - Scheduling](http://masstransit-project.com/advanced/scheduling/rabbitmq-delayed.html).
 
 ## Documentation
 
-The [documentation](https://hub.docker.com/_/rabbitmq/) is the same as the default management-alpine image.
+The [documentation](https://hub.docker.com/_/rabbitmq/) is the same as the default `management` image.


### PR DESCRIPTION
**Fix #6**

---

The GitHub Action now reads the RabbitMQ version from the Dockerfile and uses that to create the tags.

Obviously, you have to make sure that the Dockerfile always contains the full RabbitMQ version in the `FROM` instruction.

Expected result:

<img width="1297" alt="image" src="https://github.com/MassTransit/docker-rabbitmq/assets/2164763/12b7a285-dcae-434d-bd3f-614c105d254f">


This is just one way of doing it. If you don't like this, some further ideas:

- Move the bash stuff to a script in the repository
- Use tags, so that the version is read from there instead of being parsed from the Dockerfile

While at it, I also updated the README removing the part that says that the image is based on the alpine variant, which is not. (You should also manually update the description on Docker Hub, I think.)