### PR TITLE
chore: add code-scanning-triage skill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM rabbitmq:3.13-management-alpine AS builder
+FROM rabbitmq:4.0-management-alpine AS builder
 
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez;
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.0.2/rabbitmq_delayed_message_exchange-4.0.2.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez;
     
-FROM rabbitmq:3.13-management-alpine
+FROM rabbitmq:4.0-management-alpine
 
-COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez
+COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez; \
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.0.2/rabbitmq_delayed_message_exchange-4.0.2.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez; \
     rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_consistent_hash_exchange rabbitmq_prometheus rabbitmq_shovel rabbitmq_shovel_management

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rabbitmq:3.12-management-alpine
 
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends curl; \
+RUN apk update; \
+    apk add curl; \
     curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez; \
     rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_consistent_hash_exchange rabbitmq_prometheus rabbitmq_shovel rabbitmq_shovel_management

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
+FROM rabbitmq:3.12-management-alpine AS builder
+
+RUN apk update; \
+    apk add curl; \
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez;
+    
 FROM rabbitmq:3.12-management-alpine
 
+COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez
 RUN apk update; \
     apk add curl; \
     curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM rabbitmq:4.0-management-alpine AS builder
+FROM rabbitmq:3.13-management-alpine AS builder
 
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.0.2/rabbitmq_delayed_message_exchange-4.0.2.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez;
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez;
     
-FROM rabbitmq:4.0-management-alpine
+FROM rabbitmq:3.13-management-alpine
 
-COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez
+COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.0.2/rabbitmq_delayed_message_exchange-4.0.2.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-4.0.2.ez; \
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez; \
     rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_consistent_hash_exchange rabbitmq_prometheus rabbitmq_shovel rabbitmq_shovel_management

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM rabbitmq:3.12-management-alpine AS builder
+FROM rabbitmq:3.13-management-alpine AS builder
 
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez;
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez;
     
-FROM rabbitmq:3.12-management-alpine
+FROM rabbitmq:3.13-management-alpine
 
-COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez
+COPY --from=builder $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez
 RUN apk update; \
     apk add curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez; \
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez; \
     rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_consistent_hash_exchange rabbitmq_prometheus rabbitmq_shovel rabbitmq_shovel_management

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rabbitmq:3.11.18-management
+FROM rabbitmq:3.12-management-alpine
 
 RUN apt-get update; \
     apt-get install -y --no-install-recommends curl; \
-    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.11.1/rabbitmq_delayed_message_exchange-3.11.1.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.11.1.ez; \
+    curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.12.0.ez; \
     rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_consistent_hash_exchange rabbitmq_prometheus rabbitmq_shovel rabbitmq_shovel_management


### PR DESCRIPTION
Adds the shared code-scanning/code-quality triage skill at `.claude/skills/code-scanning-triage/SKILL.md`.

This repo has no `CLAUDE.md`, so no working-agreement bullet was added — skill-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)